### PR TITLE
Dark Mode support example

### DIFF
--- a/payloads/DumpPayload.go
+++ b/payloads/DumpPayload.go
@@ -1,24 +1,19 @@
 package payloads
 
 import (
+	"strings"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gomarkdown/markdown"
 )
 
 // NewDumpPayload creates a new Dump Payload
 func NewDumpPayload(value interface{}) Payload {
-	style := `
-	<style>
-		.go-dump pre {
-			position:relative;
-			overflow-x: auto;
-			width: 100%;
-			padding: 10px 10px;
-			height: auto;
-			background-color: #f3f3f3;
-		}
-	</style>`
-	md := []byte("``` \n"+spew.Sdump(value)+"\n```")
+	md := []byte("``` \n" + spew.Sdump(value) + "\n```")
 	output := markdown.ToHTML(md, nil, nil)
-	return NewCustomPayload(style+`<div class="go-dump">`+string(output) + "</div>", "")
+	styledOutput := strings.Replace(string(output), "<pre><code>", strings.Join([]string{
+		`<pre class="relative overflow-x-auto w-full p-5 h-auto bg-gray-100 dark:bg-gray-800">`,
+		`<code class="h-auto">`,
+	}, ""), 1)
+	return NewCustomPayload(styledOutput, "")
 }


### PR DESCRIPTION
# Summary

Spatie Ray uses TailwindCSS and has CSS classes available. This is an example PR of switch to use the TailwindCSS classes to easily enable dark mode background colors.

# Screenshots

<img width="1080" alt="dark" src="https://user-images.githubusercontent.com/13930605/192368729-e97a67ba-d1bb-4d2a-8343-1e241dd4cea7.png">
<img width="1080" alt="light" src="https://user-images.githubusercontent.com/13930605/192368732-9dbad8a7-79fa-4ba9-b8fd-8026915bc970.png">
